### PR TITLE
Replace api3.eth.link with api3.eth

### DIFF
--- a/api3-whitepaper.tex
+++ b/api3-whitepaper.tex
@@ -553,7 +553,7 @@ This typically results in honest and efficient allocation of development and eco
 \subsection{API3 DAO}
 \label{sec:api3-dao}
 
-To decentralize the governance of both dAPIs and the project as a whole, API3 is governed by a DAO\footnote{\url{https://api3.eth.link} is a dashboard for the API3 DAO that is maintained by the core technical team.}.
+To decentralize the governance of both dAPIs and the project as a whole, API3 is governed by a DAO\footnote{\url{https://api3.eth} is a dashboard for the API3 DAO that is maintained by the core technical team.}.
 The governance is entirely decentralized and open, meaning that all stakeholders are able to participate in the governance of the project directly.
 This is achieved through the API3 token, which grants voting power in the API3 DAO through the mechanics described in Section~\ref{sec:api3-tokenomics}.
 

--- a/api3-whitepaper.tex
+++ b/api3-whitepaper.tex
@@ -553,7 +553,7 @@ This typically results in honest and efficient allocation of development and eco
 \subsection{API3 DAO}
 \label{sec:api3-dao}
 
-To decentralize the governance of both dAPIs and the project as a whole, API3 is governed by a DAO\footnote{\url{https://api3.eth} is a dashboard for the API3 DAO that is maintained by the core technical team.}.
+To decentralize the governance of both dAPIs and the project as a whole, API3 is governed by a DAO\footnote{Refer to \url{https://api3.org/} for the recommended method to access the DAO.}.
 The governance is entirely decentralized and open, meaning that all stakeholders are able to participate in the governance of the project directly.
 This is achieved through the API3 token, which grants voting power in the API3 DAO through the mechanics described in Section~\ref{sec:api3-tokenomics}.
 


### PR DESCRIPTION
See: https://api3workspace.slack.com/archives/C02ALA11APM/p1678106079904879?thread_ts=1678093121.848019&cid=C02ALA11APM

The idea is to be consistent with how to access the DAO dashboard and avoid suing `.eth.link` which is unsafe.