### PR TITLE
Update API3 DAO tracker URL

### DIFF
--- a/api3-whitepaper.tex
+++ b/api3-whitepaper.tex
@@ -660,7 +660,7 @@ The API3 DAO will require the users to burn or time-lock API3 tokens to receive 
 API3 services being used will cause a shortage in API3 supply, which will benefit all token holders, and not only the stakers.
 This implies that the staking rewards should be regulated to ensure that a certain portion of the API3 token holders stake, which will secure the governance of the project and provide collateral for service coverage products.
 To this end, the API3 DAO sets a ``stake target", which is a percentage of the total token supply.
-Every week, the reward amount is updated iteratively, i.e., increases if the staked amount is below the stake target, and vice versa.\footnote{\url{https://enormous.cloud/dao/api3/tracker} is an explorer for the API3 DAO that is maintained by Enormous.Cloud. You can use it to see the history of the reward amounts to date.}
+Every week, the reward amount is updated iteratively, i.e., increases if the staked amount is below the stake target, and vice versa.\footnote{\url{https://tracker.api3.org/} is an explorer for the API3 DAO. You can use it to see the history of the reward amounts to date.}
 
 It is challenging to incentivize good governance through staking rewards, as governance quality is not easily quantified.
 For example, participation is generally considered to be desirable, yet voting on a proposal that will already pass is redundant in most cases, and actively abstaining is a legitimate stance.


### PR DESCRIPTION
Closes #16. I randomly saw the issue and thought I'd make a quick PR, though it isn't urgently necessary since the old URL (currently) redirects to the new one. I also removed the Enormous.Cloud reference because the website enormous.cloud returns a 500 and the tracker is now within the api3.org domain.